### PR TITLE
fix: generate files to current directory

### DIFF
--- a/contrib/generate-json-pool-list.py
+++ b/contrib/generate-json-pool-list.py
@@ -4,7 +4,7 @@ import json
 import glob
 import sys
 
-output_file_name = "generated/pool-list.json"
+output_file_name = "pool-list.json"
 
 if len(sys.argv) == 2:
     print(f"Using {sys.argv[1]} as output file name.")

--- a/contrib/generate-old-pools-json.py
+++ b/contrib/generate-old-pools-json.py
@@ -4,7 +4,7 @@ import json
 import glob
 import sys
 
-output_file_name = "generated/pools.json"
+output_file_name = "pools.json"
 
 if len(sys.argv) == 2:
     print(f"Using {sys.argv[1]} as output file name.")


### PR DESCRIPTION
The files were previously located in the "generated" folder which was removed in https://github.com/bitcoin-data/mining-pools/pull/79. As the folder does not exist anymore, the scripts fail.