### PR TITLE
add: Carbon Negative miner address

### DIFF
--- a/pools/carbon-negative-unidentified.json
+++ b/pools/carbon-negative-unidentified.json
@@ -2,8 +2,9 @@
   "id": 13,
   "name": "Carbon Negative (unidentified)",
   "addresses": [
-    "33SAB6pzbhEGPbfY6NVgRDV7jVfspZ3A3Z"
+    "33SAB6pzbhEGPbfY6NVgRDV7jVfspZ3A3Z",
+    "3KZDwmJHB6QJ13QPXHaW7SS3yTESFPZoxb"
   ],
   "tags": [],
-  "link": "https://github.com/0xB10C/known-mining-pools/issues/48"
+  "link": "https://github.com/bitcoin-data/mining-pools/issues/48"
 }


### PR DESCRIPTION
The miner switched to a new address (3KZDwmJHB6QJ13QPXHaW7SS3yTESFPZoxb) but kept re-using the same coinbase script hex of `01201209090920090920090`.

Closes #83

related #48 