### PR TITLE
add: Luxor Pool tag and address

### DIFF
--- a/pools/luxor.json
+++ b/pools/luxor.json
@@ -2,10 +2,12 @@
   "id": 4,
   "name": "Luxor",
   "addresses": [
-    "1MkCDCzHpBsYQivp8MxjY5AkTGG1f2baoe"
+    "1MkCDCzHpBsYQivp8MxjY5AkTGG1f2baoe",
+    "39bitUyBcUu3y3hRTtYprKbTp712t4ZWqK"
   ],
   "tags": [
-    "/LUXOR/"
+    "/LUXOR/",
+    "Powered by Luxor Tech"
   ],
   "link": "https://mining.luxor.tech"
 }


### PR DESCRIPTION
Adds the tag `Powered by Luxor Tech` and the address `39bitUyBcUu3y3hRTtYprKbTp712t4ZWqK` to the Luxor pool entity.

See also: https://explorer.btc.com/btc/pool/99