### PR TITLE
add: NiceHash address and tag

### DIFF
--- a/pools/nicehash.json
+++ b/pools/nicehash.json
@@ -1,9 +1,12 @@
 {
   "id": 103,
   "name": "NiceHash",
-  "addresses": [],
-  "tags": [
-    "/NiceHashSolo"
+  "addresses": [
+    "bc1qvfzssz36y4gxcg9gh234rzem9k0vrdlx4kq5sg"
   ],
-  "link": "https://solo.nicehash.com"
+  "tags": [
+    "/NiceHashSolo",
+    "/NiceHash/"
+  ],
+  "link": "https://nicehash.com"
 }


### PR DESCRIPTION
NiceHash apparently has their own pool (see #86). They've mined about 30 blocks since October 2022.

See https://www.nicehash.com/my/easymining/recent-blocks?coin=BTC&page=0 (requires login)

Some blocks they've mined:

- https://mempool.space/block/0000000000000000000191fabac23dc46064d274bb6c651275774d70c582d90e
- https://mempool.space/block/000000000000000000049348fb58bc21dbb230893b622bbb478c5fe8a6f3543e
- https://mempool.space/block/000000000000000000016df2f1587f6ef04df009240be3c7f42040f2b432f78a