### PR TITLE
add: ocean.xyz pool

### DIFF
--- a/pools/ocean.json
+++ b/pools/ocean.json
@@ -1,0 +1,9 @@
+{
+  "id": 145,
+  "name": "Ocean.xyz",
+  "addresses": [],
+  "tags": [
+    "OCEAN.XYZ"
+  ],
+  "link": "https://ocean.xyz/"
+}


### PR DESCRIPTION
The pool pays to the miners directly and thus doesn't have a coinbase output address

See e.g. this block:
https://mempool.space/block/0000000000000000000247e9c51c7e3091d43dbd5f5ea30539d0307c1ad4a9cc